### PR TITLE
Fix example config displayed in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ local builtin = require("statuscol.builtin")
 local cfg = {
   separator = false,     -- separator between line number and buffer text ("│" or extra " " padding)
   -- Builtin line number string options for ScLn() segment
-  thousands = false      -- or line number thousands separator string ("." / ",")
+  thousands = false,     -- or line number thousands separator string ("." / ",")
   relculright = false,   -- whether to right-align the cursor line number with 'relativenumber' set
   -- Custom line number string options for ScLn() segment
   lnumfunc = nil,        -- custom function called by ScLn(), should return a string

--- a/doc/statuscol.txt
+++ b/doc/statuscol.txt
@@ -41,7 +41,7 @@ DEFAULT OPTIONS ~
     local cfg = {
       separator = false,     -- separator between line number and buffer text ("│" or extra " " padding)
       -- Builtin line number string options for ScLn() segment
-      thousands = false      -- or line number thousands separator string ("." / ",")
+      thousands = false,     -- or line number thousands separator string ("." / ",")
       relculright = false,   -- whether to right-align the cursor line number with 'relativenumber' set
       -- Custom line number string options for ScLn() segment
       lnumfunc = nil,        -- custom function called by ScLn(), should return a string


### PR DESCRIPTION
This PR just adds a comma to separate table items correctly in the example config.