### PR TITLE
fix: avoid repeat foldclose or foldopen chars when `'wrap'` is set

### DIFF
--- a/lua/statuscol/builtin.lua
+++ b/lua/statuscol/builtin.lua
@@ -48,7 +48,9 @@ function M.foldfunc(args)
   -- For each column, add a foldopen, foldclosed, foldsep or padding char
   local range = level < width and level or width
   for col = 1, range do
-    if closed and (col == level or col == width) then
+    if args.virtnum ~= 0 then
+      string = string..args.fold.sep
+    elseif closed and (col == level or col == width) then
       string = string..args.fold.close
     elseif foldinfo.start == args.lnum and first_level + col > foldinfo.llevel then
       string = string..args.fold.open


### PR DESCRIPTION
Before:
![image](https://github.com/luukvbaal/statuscol.nvim/assets/61115159/394b86a9-3028-4a63-9958-629586d7be98)

After:
![image](https://github.com/luukvbaal/statuscol.nvim/assets/61115159/d7b53681-9bbe-4cd9-978e-f2a73c2f5b4b)

And I think there's no need to offer an option to configure.