### PR TITLE
fix(?): s.ns can be nil

### DIFF
--- a/lua/statuscol.lua
+++ b/lua/statuscol.lua
@@ -49,7 +49,7 @@ local function update_sign_defined(win, ext, reassign)
       if ext then
         s.text = s.sign_text
         if not idmap[s.ns_id] then update_nsidmap() end
-        s.ns = idmap[s.ns_id]
+        s.ns = idmap[s.ns_id] or ""
         if s.sign_hl_group then name = name..s.sign_hl_group end
       end
       s.wtext = s.text:gsub("%s", "")


### PR DESCRIPTION
I was getting the following error on nightly v0.10.0-dev-2445+g2e1f5055a. There is no error when using v0.9.2.
```
E5108: Error executing lua .../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:69: attempt to index field 'ns' (a nil value) stack traceback:
	.../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:69: in function 'update_sign_defined'
	.../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:190: in function 'place_signs'
	.../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:248: in function 'update_callargs'
	.../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:284: in function <.../.local/share/nvim/lazy/statuscol.nvim/lua/statuscol.lua:262>
```

I don't know the root cause, but adding an ``` or "" ``` seems to fix it.